### PR TITLE
Merge Terrox’s Foundry V12 compatibility patch – first step toward full V13 support

### DIFF
--- a/js/cache.js
+++ b/js/cache.js
@@ -57,21 +57,21 @@ class Cache {
 export class GriddedCache extends Cache {
 	reset() {
 		super.reset();
-		if (canvas.grid.isHex && canvas.grid.grid.columnar) {
-			this.gridWidth = Math.ceil(canvas.dimensions.width / ((3 / 4) * canvas.grid.w));
+		if (canvas.grid.isHexagonal && canvas.grid.columnar) {
+			this.gridWidth = Math.ceil(canvas.dimensions.width / ((3 / 4) * canvas.grid.sizeX));
 		} else {
-			this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
+			this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.sizeX);
 		}
-		if (canvas.grid.isHex && !canvas.grid.grid.columnar) {
-			this.gridHeight = Math.ceil(canvas.dimensions.height / ((3 / 4) * canvas.grid.h));
+		if (canvas.grid.isHexagonal && !canvas.grid.columnar) {
+			this.gridHeight = Math.ceil(canvas.dimensions.height / ((3 / 4) * canvas.grid.sizeY));
 		} else {
-			this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
+			this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.sizeY);
 		}
 	}
 
 	static getSnapPointIndexForTokenData(tokenData) {
 		if (canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) return 0;
-		if (canvas.grid.isHex) {
+		if (canvas.grid.isHexagonal) {
 			if (tokenData.hexSizeSupport?.altSnappingFlag) {
 				return tokenData.hexSizeSupport.borderSize % 2;
 			} else {
@@ -95,9 +95,8 @@ export class GriddedCache extends Cache {
 		let node = graph[pos.y][pos.x];
 		if (!node) {
 			const neighbors = [];
-			for (const neighborPos of canvas.grid.grid.getNeighbors(pos.y, pos.x).map(([y, x]) => {
-				return {x, y};
-			})) {
+			for (const neighborPos of canvas.grid.getAdjacentOffsets({x: pos.x, y: pos.y})
+					.map(a => { return {x: (a.i - 1) + pos.x, y: (a.j - 1) + pos.y} })) {
 				if (
 					neighborPos.x < 0 ||
 					neighborPos.y < 0 ||
@@ -219,7 +218,7 @@ export function stepCollidesWithWall(from, to, tokenData, adjustPos = false) {
 		adjustedStart = stepStart;
 	}
 	adjustedStart.t = adjustedStart.b = tokenData.elevation;
-	const source = new VisionSource({});
+	const source = new foundry.canvas.sources.PointVisionSource({});
 	return CONFIG.Canvas.polygonBackends.move.testCollision(adjustedStart, stepEnd, {
 		mode: "any",
 		type: "move",

--- a/js/foundry_fixes.js
+++ b/js/foundry_fixes.js
@@ -1,17 +1,19 @@
-// Wrapper to fix a FoundryVTT bug that causes the return values of canvas.grid.grid.getPixelsFromGridPosition to be ordered inconsistently
+// Wrapper to fix a FoundryVTT bug that causes the return values of canvas.grid.getPixelsFromGridPosition to be ordered inconsistently
 
 // https://gitlab.com/foundrynet/foundryvtt/-/issues/4705
 export function getPixelsFromGridPosition(xGrid, yGrid) {
+	const coord = canvas.grid.getTopLeftPoint({i: xGrid, j: yGrid});
 	if (canvas.grid.type !== CONST.GRID_TYPES.GRIDLESS) {
-		return canvas.grid.grid.getPixelsFromGridPosition(yGrid, xGrid);
+		return [coord.y, coord.x];
 	}
-	return canvas.grid.grid.getPixelsFromGridPosition(xGrid, yGrid);
+	// return canvas.grid.getPixelsFromGridPosition(xGrid, yGrid);
+	return [coord.x, coord.y];
 }
 
-// Wrapper to fix a FoundryVTT bug that causes the return values of canvas.grid.grid.getPixelsFromGridPosition to be ordered inconsistently
+// Wrapper to fix a FoundryVTT bug that causes the return values of canvas.grid.getPixelsFromGridPosition to be ordered inconsistently
 // https://gitlab.com/foundrynet/foundryvtt/-/issues/4705
 export function getGridPositionFromPixels(xPixel, yPixel) {
-	const [x, y] = canvas.grid.grid.getGridPositionFromPixels(xPixel, yPixel);
+	const [x, y] = canvas.grid.getGridPositionFromPixels(xPixel, yPixel);
 	if (canvas.grid.type !== CONST.GRID_TYPES.GRIDLESS) return [y, x];
 	return [x, y];
 }

--- a/js/main.js
+++ b/js/main.js
@@ -22,14 +22,14 @@ function initializePathfinder(from, to, options) {
 					? token.losHeight
 					: token.document.elevation;
 		}
-		if (canvas.grid.isHex) {
+		if (canvas.grid.isHexagonal) {
 			tokenData.size = getHexTokenSize(token);
 			tokenData.altOrientation = getAltOrientationFlagForToken(token, tokenData.size);
 		}
 	} else {
 		tokenData = {width: 1, height: 1};
 		elevation = elevation ?? 0;
-		if (canvas.grid.isHex) {
+		if (canvas.grid.isHexagonal) {
 			tokenData.size = 1;
 			tokenData.altOrientation = false;
 		}

--- a/js/pathfinder.js
+++ b/js/pathfinder.js
@@ -35,8 +35,8 @@ export class GriddedPathfinder {
 			node => node.estimated,
 		);
 		this.previousNodes = new Set();
-		this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
-		this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
+		this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.sizeX);
+		this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.sizeY);
 		this.startNode = cache.getInitializedNode(
 			this.startPos,
 			this.sizeIndex,

--- a/js/util.js
+++ b/js/util.js
@@ -11,7 +11,7 @@ function getSnapPointForTokenData(x, y, tokenData) {
 	if (canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) {
 		return new PIXI.Point(x, y);
 	}
-	if (canvas.grid.isHex) {
+	if (canvas.grid.isHexagonal) {
 		if (tokenData.hexSizeSupport?.altSnappingFlag) {
 			if (tokenData.hexSizeSupport.borderSize % 2 === 0) {
 				const snapPoint = findVertexSnapPoint(x, y, tokenData.hexSizeSupport.altOrientationFlag);
@@ -24,18 +24,18 @@ function getSnapPointForTokenData(x, y, tokenData) {
 		}
 	}
 
-	const [topLeftX, topLeftY] = canvas.grid.getTopLeft(x, y);
+	const {x: topLeftX, y: topLeftY} = canvas.grid.getTopLeftPoint({x: x, y: y});
 	let cellX, cellY;
-	if (tokenData.width % 2 === 0) cellX = x - canvas.grid.h / 2;
+	if (tokenData.width % 2 === 0) cellX = x - canvas.grid.sizeY / 2;
 	else cellX = x;
-	if (tokenData.height % 2 === 0) cellY = y - canvas.grid.h / 2;
+	if (tokenData.height % 2 === 0) cellY = y - canvas.grid.sizeY / 2;
 	else cellY = y;
-	const [centerX, centerY] = canvas.grid.getCenter(cellX, cellY);
+	const {x: centerX, y: centerY} = canvas.grid.getCenterPoint({x: cellX, y: cellY});
 	let snapX, snapY;
 	// Tiny tokens can snap to the cells corners
 	if (tokenData.width <= 0.5) {
 		const offsetX = x - topLeftX;
-		const subGridWidth = Math.floor(canvas.grid.w / 2);
+		const subGridWidth = Math.floor(canvas.grid.sizeX / 2);
 		const subGridPosX = Math.floor(offsetX / subGridWidth);
 		snapX = topLeftX + (subGridPosX + 0.5) * subGridWidth;
 	}
@@ -45,17 +45,17 @@ function getSnapPointForTokenData(x, y, tokenData) {
 	}
 	// All remaining tokens (those with even or fractional multipliers on square grids) snap to the intersection points of the grid
 	else {
-		snapX = centerX + canvas.grid.w / 2;
+		snapX = centerX + canvas.grid.sizeX / 2;
 	}
 	if (tokenData.height <= 0.5) {
 		const offsetY = y - topLeftY;
-		const subGridHeight = Math.floor(canvas.grid.h / 2);
+		const subGridHeight = Math.floor(canvas.grid.sizeY / 2);
 		const subGridPosY = Math.floor(offsetY / subGridHeight);
 		snapY = topLeftY + (subGridPosY + 0.5) * subGridHeight;
 	} else if (Math.round(tokenData.height) % 2 === 1 || tokenData.height < 1) {
 		snapY = centerY;
 	} else {
-		snapY = centerY + canvas.grid.h / 2;
+		snapY = centerY + canvas.grid.sizeY / 2;
 	}
 	return new PIXI.Point(snapX, snapY);
 }
@@ -144,7 +144,7 @@ export function getAreaFromPositionAndShape(position, shape) {
 	return shape.map(space => {
 		let x = position.x + space.x;
 		let y = position.y + space.y;
-		if (canvas.grid.isHex) {
+		if (canvas.grid.isHexagonal) {
 			let shiftedRow;
 			if (canvas.grid.grid.even) shiftedRow = 1;
 			else shiftedRow = 0;
@@ -164,7 +164,7 @@ export function getAreaFromPositionAndShape(position, shape) {
 
 export function buildOffset(startPos, endPos) {
 	const offset = {x: endPos.x - startPos.x, y: endPos.y - startPos.y};
-	if (canvas.grid.isHex) {
+	if (canvas.grid.isHexagonal) {
 		if (canvas.grid.grid.columnar) {
 			offset.adjustmentNeeded = (startPos.x - endPos.x) % 2 !== 0;
 			offset.originEven = startPos.x % 2 === 0;
@@ -178,7 +178,7 @@ export function buildOffset(startPos, endPos) {
 
 export function applyOffset(origin, offset) {
 	const pos = {x: origin.x + offset.x, y: origin.y + offset.y};
-	if (canvas.grid.isHex && offset.adjustmentNeeded) {
+	if (canvas.grid.isHexagonal && offset.adjustmentNeeded) {
 		if (canvas.grid.grid.columnar) {
 			if ((origin.x % 2 === 0) !== offset.originEven) {
 				if (offset.originEven === canvas.grid.grid.even) {

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
 	"version": "1.1.0",
 	"compatibility": {
 		"minimum": "11",
-		"verified": "11"
+		"verified": "12"
 	},
 	"authors": [
 		{
@@ -15,11 +15,10 @@
 		}
 	],
 	"esmodules": ["js/main.js"],
-	"url": "https://github.com/manuelVo/foundryvtt-routinglib",
-	"download": "https://github.com/manuelVo/foundryvtt-routinglib/releases/download/v1.1.0/routinglib-1.1.0.zip",
-	"manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-routinglib/master/module.json",
+	"url": "https://github.com/Terrox/foundryvtt-routinglib",
+	"download": "https://github.com/Terrox/foundryvtt-routinglib/releases/download/v1.1.1/routinglib-1.1.1.zip",
+	"manifest": "https://raw.githubusercontent.com/Terrox/foundryvtt-routinglib/master/module.json",
 	"readme": "https://github.com/manuelVo/foundryvtt-routinglib/blob/master/README.md",
-	"changelog": "https://github.com/manuelVo/foundryvtt-routinglib/blob/master/CHANGELOG.md",
+	"changelog": "https://github.com/Terrox/foundryvtt-routinglib/blob/develop/CHANGELOG.md",
 	"bugs": "https://github.com/manuelVo/foundryvtt-routinglib/issues",
-	"allowBugReporter": false
 }

--- a/module.json
+++ b/module.json
@@ -20,5 +20,5 @@
 	"manifest": "https://raw.githubusercontent.com/Terrox/foundryvtt-routinglib/master/module.json",
 	"readme": "https://github.com/manuelVo/foundryvtt-routinglib/blob/master/README.md",
 	"changelog": "https://github.com/Terrox/foundryvtt-routinglib/blob/develop/CHANGELOG.md",
-	"bugs": "https://github.com/manuelVo/foundryvtt-routinglib/issues",
+	"bugs": "https://github.com/manuelVo/foundryvtt-routinglib/issues"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"id": "routinglib",
 	"title": "routinglib",
 	"description": "A library module to calculate a path between two points",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"compatibility": {
 		"minimum": "11",
 		"verified": "12"

--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
 	],
 	"esmodules": ["js/main.js"],
 	"url": "https://github.com/Terrox/foundryvtt-routinglib",
-	"download": "https://github.com/Terrox/foundryvtt-routinglib/releases/download/v1.1.1/routinglib-1.1.1.zip",
+	"download": "https://github.com/Terrox/foundryvtt-routinglib/archive/refs/tags/develop.zip",
 	"manifest": "https://raw.githubusercontent.com/Terrox/foundryvtt-routinglib/master/module.json",
 	"readme": "https://github.com/manuelVo/foundryvtt-routinglib/blob/master/README.md",
 	"changelog": "https://github.com/Terrox/foundryvtt-routinglib/blob/develop/CHANGELOG.md",

--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
 	],
 	"esmodules": ["js/main.js"],
 	"url": "https://github.com/Terrox/foundryvtt-routinglib",
-	"download": "https://github.com/Terrox/foundryvtt-routinglib/archive/refs/tags/develop.zip",
+	"download": "https://github.com/Terrox/foundryvtt-routinglib/releases/download/develop/routinglib-1-1-1.zip",
 	"manifest": "https://raw.githubusercontent.com/Terrox/foundryvtt-routinglib/master/module.json",
 	"readme": "https://github.com/manuelVo/foundryvtt-routinglib/blob/master/README.md",
 	"changelog": "https://github.com/Terrox/foundryvtt-routinglib/blob/develop/CHANGELOG.md",


### PR DESCRIPTION
# Why
Routinglib v1.1.0 fails on Foundry 12+ because of canvas-API refactors.
Terrox’s fork fixes those breaking changes for V12 **but does not yet
cover the additional changes introduced in V13**.  Pulling these commits
into my fork gives us a clean baseline before layering on the V13 work.

## What’s included from Terrox
* **module.json**
  - removes deprecated `allowBugReporter`
  - bumps `minimum` / `verified` to “12”
* **Geometry namespace fix**
  - Updates the Ray import to `foundry.canvas.geometry`
* **Misc lint / README tweaks**

Everything here loads and runs on Foundry 12.331 with no console errors.

## Still needed for full V13 compatibility (to be done next)
- Update `module.json` → `"minimum": "13", "verified": "13"`
- Replace other moved imports (e.g. `CanvasEdges` → `foundry.canvas.geometry.edges`)
- Add a wrapper/override for `Token.prototype.findMovementPath`
  that calls `routinglib.calculatePath()` and falls back to the core clip.
- Re-test on 13.332 (square, hex, grid-less, difficult terrain)
- Bump version to 1.2.0 when finished

## Testing notes for this PR
1. Copy this branch’s ZIP into `Data/modules/` on Foundry **12.331**.
2. Launch a world → load a token → drag the ruler: no red errors.
3. Path-finding still crashes on **13.332** (expected; will be fixed in
   the follow-up PR).

Merging now gives us a stable base for the V13 port while preserving
Terrox’s authorship history.